### PR TITLE
Remove "ember-lodash" dependency

### DIFF
--- a/addon/-private/indices-implementation.js
+++ b/addon/-private/indices-implementation.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import _lang from 'lodash/lang';
 
 /**
  * Indices Implementation
@@ -18,7 +17,7 @@ export default function (value, query, options) {
   const indices = findIndicesOf(query, value, options.caseSensitive);
 
   // If we couldn't find any match, return input untouched
-  if (_lang.isEmpty(indices)) {
+  if (Ember.isEmpty(indices)) {
     return Ember.String.htmlSafe(value);
   }
 

--- a/addon/helpers/text-highlight.js
+++ b/addon/helpers/text-highlight.js
@@ -3,11 +3,8 @@
  */
 
 import Ember from 'ember';
-import _lang from 'lodash/lang';
-import _array from 'lodash/array';
-import _object from 'lodash/object';
 
-import {isSafari} from 'ember-text-highlight/-private/env-detection';
+import { isSafari } from 'ember-text-highlight/-private/env-detection';
 
 import indicesImplementation from 'ember-text-highlight/-private/indices-implementation';
 import regexImplementation from 'ember-text-highlight/-private/regex-implementation';
@@ -34,11 +31,12 @@ const DEFAULT_OPTIONS = {
  * Picks the best implementation concerning input and environment.
  */
 export default Ember.Helper.helper(function (params = [], options = DEFAULT_OPTIONS) {
-  let value, query;
+  const value = findValueAndTransformToStringIfApplicable(params);
+  const query = options.query;
 
   // validate and transform input
-  const queryIsValid = _lang.isString(query = options.query) && !_lang.isEmpty(query.trim());
-  const valueIsValid = _lang.isString(value = findValueAndTransformToStringIfApplicable(params)) && !_lang.isEmpty(value.trim());
+  const queryIsValid = Ember.typeOf(query) === 'string' && !Ember.isEmpty(query.trim());
+  const valueIsValid = Ember.typeOf(value) === 'string' && !Ember.isEmpty(value.trim());
 
   if (!queryIsValid) {
     return Ember.String.htmlSafe(value);
@@ -48,7 +46,8 @@ export default Ember.Helper.helper(function (params = [], options = DEFAULT_OPTI
     return '';
   }
 
-  options = _object.merge(DEFAULT_OPTIONS, _lang.clone(options));
+  //options = _object.merge(DEFAULT_OPTIONS, _lang.clone(options));
+  options = Ember.assign(DEFAULT_OPTIONS, options);
 
   // as of a certain value length, regular expressions will likely start to exceed the performance of our indices
   // implementation
@@ -69,6 +68,6 @@ export default Ember.Helper.helper(function (params = [], options = DEFAULT_OPTI
 });
 
 function findValueAndTransformToStringIfApplicable(params) {
-  const value = _array.nth(params, 0);
-  return _lang.isNumber(value) ? value.toString() : value;
+  const value = params[0];
+  return Ember.typeOf(value) === 'number' ? value.toString() : value;
 }

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "test-all": "COVERAGE=true node_modules/ember-cli/bin/ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.11.0",
-    "ember-lodash": "^4.17.6"
+    "ember-cli-babel": "^6.11.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "coveralls": "^3.0.0",
     "ember-ajax": "^3.0.0",
+    "ember-source": "~2.18.0",
     "ember-cli": "~2.17.0",
     "ember-cli-code-coverage": "^0.4.2",
     "ember-cli-dependency-checker": "^2.0.0",


### PR DESCRIPTION
Replaced the few usages of lodash classes with Ember helpers or native implementation.

This was driven by the fact that the add-on adds ~68KB (!) to the host app bundle by importing `ember-lodash`:

![screenshot 2019-01-24 at 15 03 57](https://user-images.githubusercontent.com/1538479/51693405-2d618c80-1fff-11e9-8ab9-e671bda6f014.png)

All tests are passing.